### PR TITLE
fix(setup): configurable Docker host ports with auto-fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Local development ports (host machine)
+# Defaults: backend 8000, frontend 3000, database 5432
+# setup.sh auto-selects the next free port if a default is already in use
+BACKEND_HOST_PORT=8000
+FRONTEND_HOST_PORT=3000
+DB_HOST_PORT=5432
+
+# Frontend API URL (must match BACKEND_HOST_PORT)
+VITE_API_BASE_URL=http://localhost:8000
+
+# Application configuration
+ENVIRONMENT=development
+DATABASE_URL=postgresql://vulnrisk:password@localhost:5432/vulnrisk
+SECRET_KEY=your-secret-key-here
+DEBUG=true
+ENABLE_DEBUG_ENDPOINTS=true
+ENABLE_AI_RISK_PREDICTION=true
+ENABLE_FEDRAMP_COMPLIANCE=true

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -167,6 +167,22 @@ curl http://localhost:8000/api/v1/config/features
 ### **Common Issues**
 
 #### **Port Already in Use**
+
+`./setup.sh` automatically selects the next available port when defaults (8000, 3000, 5432) are taken and saves the choice in `.env`.
+
+To set ports manually, copy `.env.example` to `.env` and edit:
+
+```bash
+BACKEND_HOST_PORT=8001
+FRONTEND_HOST_PORT=3001
+DB_HOST_PORT=5433
+VITE_API_BASE_URL=http://localhost:8001
+```
+
+Then run `./setup.sh` or `docker compose up -d`.
+
+To free a port manually:
+
 ```bash
 # Kill existing processes
 lsof -ti:8000 | xargs kill -9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   backend:
     build: ./backend
     ports:
-      - "8000:8000"
+      - "${BACKEND_HOST_PORT:-8000}:8000"
     environment:
       - PYTHONPATH=/app
       - ENVIRONMENT=development
@@ -15,9 +15,9 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "3000:3000"
+      - "${FRONTEND_HOST_PORT:-3000}:3000"
     environment:
-      - VITE_API_BASE_URL=http://localhost:8000
+      - VITE_API_BASE_URL=${VITE_API_BASE_URL:-http://localhost:8000}
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -31,7 +31,7 @@ services:
       - POSTGRES_USER=vulnrisk
       - POSTGRES_PASSWORD=password
     ports:
-      - "5432:5432"
+      - "${DB_HOST_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,13 @@ cd vulnrisk
 ./setup.sh
 ```
 
-**What You Get:**
+**What You Get** (default ports; configurable via `.env`):
 - ✅ **Frontend**: http://localhost:3000  
 - ✅ **Backend API**: http://localhost:8000  
 - ✅ **API Docs**: http://localhost:8000/docs  
 - ✅ **Database**: PostgreSQL on localhost:5432  
+
+If a default port is already in use, `./setup.sh` picks the next free port and writes it to `.env`. Copy `.env.example` to customize ports before setup.
 
 ## 🎯 **Why VulnRisk?**
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,78 +1,177 @@
 #!/bin/bash
 
-# 🚀 VulnRisk Local Development Setup
-# This script sets up your local development environment
+# VulnRisk Local Development Setup
 
-set -e  # Exit on any error
+set -e
 
-echo "🚀 Setting up VulnRisk local development environment..."
+DEFAULT_BACKEND_PORT=8000
+DEFAULT_FRONTEND_PORT=3000
+DEFAULT_DB_PORT=5432
 
-# Check prerequisites
-echo "📋 Checking prerequisites..."
-command -v docker >/dev/null 2>&1 || { echo "❌ Docker is required but not installed. Please install Docker first."; exit 1; }
-command -v docker compose >/dev/null 2>&1 || { echo "❌ Docker Compose is required but not installed. Please install Docker Compose first."; exit 1; }
+echo "Setting up VulnRisk local development environment..."
 
-# Make sure we're in the right directory
+echo "Checking prerequisites..."
+command -v docker >/dev/null 2>&1 || { echo "Docker is required but not installed."; exit 1; }
+command -v docker compose >/dev/null 2>&1 || { echo "Docker Compose is required but not installed."; exit 1; }
+
 if [ ! -f "backend/pyproject.toml" ] || [ ! -f "backend/uv.lock" ]; then
-    echo "❌ Please run this script from the VulnRisk root directory"
+    echo "Please run this script from the VulnRisk root directory."
     exit 1
 fi
 
-# Create .env file for local development
-echo "🔧 Creating local environment configuration..."
-cat > .env << 'ENV_EOF'
-# Local Development Configuration
-ENVIRONMENT=development
-DATABASE_URL=postgresql://vulnrisk:password@localhost:5432/vulnrisk
-SECRET_KEY=your-secret-key-here
-DEBUG=true
-ENABLE_DEBUG_ENDPOINTS=true
-ENABLE_AI_RISK_PREDICTION=true
-ENABLE_FEDRAMP_COMPLIANCE=true
-ENV_EOF
+is_port_in_use() {
+    local port=$1
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -iTCP:"$port" -sTCP:LISTEN -Pn >/dev/null 2>&1
+        return $?
+    fi
+    if command -v nc >/dev/null 2>&1; then
+        nc -z localhost "$port" >/dev/null 2>&1
+        return $?
+    fi
+    return 1
+}
 
-# Start the services
-echo "🚀 Starting services..."
+find_free_port() {
+    local start=$1
+    local port=$start
+    local max=$((start + 100))
+
+    while [ "$port" -lt "$max" ]; do
+        if ! is_port_in_use "$port"; then
+            echo "$port"
+            return 0
+        fi
+        port=$((port + 1))
+    done
+
+    echo "Could not find a free port starting at ${start}." >&2
+    return 1
+}
+
+read_env_var() {
+    local key=$1
+    local default=$2
+    if [ -f .env ] && grep -q "^${key}=" .env; then
+        grep "^${key}=" .env | tail -1 | cut -d= -f2-
+    else
+        echo "$default"
+    fi
+}
+
+upsert_env() {
+    local key=$1
+    local value=$2
+
+    if [ ! -f .env ]; then
+        touch .env
+    fi
+
+    if grep -q "^${key}=" .env; then
+        if [[ "$OSTYPE" == darwin* ]]; then
+            sed -i '' "s|^${key}=.*|${key}=${value}|" .env
+        else
+            sed -i "s|^${key}=.*|${key}=${value}|" .env
+        fi
+    else
+        echo "${key}=${value}" >> .env
+    fi
+}
+
+ensure_port_available() {
+    local var_name=$1
+    local current_port=$2
+    local default_port=$3
+    local label=$4
+
+    if ! is_port_in_use "$current_port"; then
+        echo "$current_port"
+        return 0
+    fi
+
+    echo "Port ${current_port} (${label}) is already in use." >&2
+    local free_port
+    free_port=$(find_free_port "$default_port")
+    echo "Using port ${free_port} for ${label} instead." >&2
+    upsert_env "$var_name" "$free_port"
+    echo "$free_port"
+}
+
+echo "Configuring local environment..."
+if [ ! -f .env ]; then
+    if [ -f .env.example ]; then
+        cp .env.example .env
+        echo "Created .env from .env.example"
+    else
+        touch .env
+    fi
+else
+    echo "Using existing .env (ports and URLs will be validated)"
+fi
+
+BACKEND_HOST_PORT=$(read_env_var "BACKEND_HOST_PORT" "$DEFAULT_BACKEND_PORT")
+FRONTEND_HOST_PORT=$(read_env_var "FRONTEND_HOST_PORT" "$DEFAULT_FRONTEND_PORT")
+DB_HOST_PORT=$(read_env_var "DB_HOST_PORT" "$DEFAULT_DB_PORT")
+
+BACKEND_HOST_PORT=$(ensure_port_available "BACKEND_HOST_PORT" "$BACKEND_HOST_PORT" "$DEFAULT_BACKEND_PORT" "backend")
+FRONTEND_HOST_PORT=$(ensure_port_available "FRONTEND_HOST_PORT" "$FRONTEND_HOST_PORT" "$DEFAULT_FRONTEND_PORT" "frontend")
+DB_HOST_PORT=$(ensure_port_available "DB_HOST_PORT" "$DB_HOST_PORT" "$DEFAULT_DB_PORT" "database")
+
+upsert_env "BACKEND_HOST_PORT" "$BACKEND_HOST_PORT"
+upsert_env "FRONTEND_HOST_PORT" "$FRONTEND_HOST_PORT"
+upsert_env "DB_HOST_PORT" "$DB_HOST_PORT"
+upsert_env "VITE_API_BASE_URL" "http://localhost:${BACKEND_HOST_PORT}"
+upsert_env "DATABASE_URL" "postgresql://vulnrisk:password@localhost:${DB_HOST_PORT}/vulnrisk"
+
+for key in ENVIRONMENT SECRET_KEY DEBUG ENABLE_DEBUG_ENDPOINTS ENABLE_AI_RISK_PREDICTION ENABLE_FEDRAMP_COMPLIANCE; do
+    if ! grep -q "^${key}=" .env 2>/dev/null; then
+        case "$key" in
+            ENVIRONMENT) upsert_env "$key" "development" ;;
+            SECRET_KEY) upsert_env "$key" "your-secret-key-here" ;;
+            DEBUG) upsert_env "$key" "true" ;;
+            ENABLE_DEBUG_ENDPOINTS|ENABLE_AI_RISK_PREDICTION|ENABLE_FEDRAMP_COMPLIANCE)
+                upsert_env "$key" "true"
+                ;;
+        esac
+    fi
+done
+
+echo "Starting services..."
 docker compose up -d
 
-# Wait for services to be ready
-echo "⏳ Waiting for services to start..."
+echo "Waiting for services to start..."
 sleep 15
 
-# Test the setup
-echo "🧪 Testing setup..."
-if curl -s http://localhost:8000/health > /dev/null; then
-    echo "✅ Backend is running!"
+echo "Testing setup..."
+if curl -s "http://localhost:${BACKEND_HOST_PORT}/health" > /dev/null; then
+    echo "Backend is running!"
 else
-    echo "❌ Backend health check failed"
-    echo "📋 Check logs with: docker compose logs backend"
+    echo "Backend health check failed"
+    echo "Check logs with: docker compose logs backend"
     exit 1
 fi
 
-if curl -s http://localhost:3000 > /dev/null; then
-    echo "✅ Frontend is running!"
+if curl -s "http://localhost:${FRONTEND_HOST_PORT}" > /dev/null; then
+    echo "Frontend is running!"
 else
-    echo "❌ Frontend health check failed"
-    echo "📋 Check logs with: docker compose logs frontend"
+    echo "Frontend health check failed"
+    echo "Check logs with: docker compose logs frontend"
     exit 1
 fi
 
 echo ""
-echo "🎉 VulnRisk is ready for local development!"
+echo "VulnRisk is ready for local development!"
 echo ""
-echo "📱 Access your application:"
-echo "   Frontend: http://localhost:3000"
-echo "   Backend API: http://localhost:8000"
-echo "   API Docs: http://localhost:8000/docs"
-echo "   Database: localhost:5432"
+echo "Access your application:"
+echo "   Frontend: http://localhost:${FRONTEND_HOST_PORT}"
+echo "   Backend API: http://localhost:${BACKEND_HOST_PORT}"
+echo "   API Docs: http://localhost:${BACKEND_HOST_PORT}/docs"
+echo "   Database: localhost:${DB_HOST_PORT}"
 echo ""
-echo "🔧 Useful commands:"
+echo "Port configuration is stored in .env (see .env.example)"
+echo ""
+echo "Useful commands:"
 echo "   View logs: docker compose logs -f"
 echo "   Stop services: docker compose down"
 echo "   Restart: docker compose restart"
 echo "   Reset everything: docker compose down -v && ./setup.sh"
-echo ""
-echo "📚 Documentation:"
-echo "   See DEVELOPER_SETUP.md for detailed instructions"
-echo ""
-echo "Happy coding! 🚀"


### PR DESCRIPTION
## Summary
Fixes port binding failures during local setup when default ports are already in use.

- Adds `.env.example` with `BACKEND_HOST_PORT`, `FRONTEND_HOST_PORT`, `DB_HOST_PORT`, and `VITE_API_BASE_URL`
- Parameterizes host port mappings in `docker-compose.yml` (container ports unchanged)
- Updates `setup.sh` to:
  - Create `.env` from `.env.example` when missing
  - Preserve existing `.env` when present
  - Detect port conflicts and auto-select the next free port
  - Keep `VITE_API_BASE_URL` and `DATABASE_URL` in sync with chosen ports
  - Run health checks against configured ports

Closes #11 